### PR TITLE
Fix the tie-breaks modal

### DIFF
--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -6165,7 +6165,7 @@ msgstr ""
 msgid "Qatar"
 msgstr ""
 
-msgid "Quick-apply a tie-break set"
+msgid "Quick-apply a tie-break set (replace actual tie-breaks)"
 msgstr ""
 
 msgid "R"

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -6167,8 +6167,8 @@ msgstr "Type de QR Code :"
 msgid "Qatar"
 msgstr "Qatar"
 
-msgid "Quick-apply a tie-break set"
-msgstr "Appliquer un ensemble de départages"
+msgid "Quick-apply a tie-break set (replace actual tie-breaks)"
+msgstr "Appliquer un ensemble de départages (remplace les départages actuels)"
 
 msgid "R"
 msgstr "R"

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -2023,10 +2023,6 @@ class TournamentAdminController(BaseEventAdminController):
     ) -> Template:
         web_context = TournamentAdminWebContext(request, tournament_id)
         tournament = web_context.get_admin_tournament()
-        if not tournament.only_ranks_on_points:
-            raise ClientException(
-                'Cannot apply a tie-break set when tie-breaks already exist.'
-            )
         raw = (data or {}).get('tie_break_set', '')
         if isinstance(raw, list):
             raw = raw[0] if raw else ''

--- a/src/web/templates/admin/tournaments/tie_breaks_modal.html
+++ b/src/web/templates/admin/tournaments/tie_breaks_modal.html
@@ -230,9 +230,67 @@
                         </div>
                     {% endfor %}
                 </form>
+                {# Tie-beak sets can be applied at any time. #}
+                {% if not rule_set_managed and tie_break_set_select_options %}
+                    <div class="mt-3">
+                        <form
+                            id="tie-break-set-apply-form"
+                            hx-post="{{ url_for(
+                                'admin-apply-tie-break-set',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                            ) }}"
+                            hx-target="body"
+                            hx-indicator="#please-wait"
+                            class="d-flex gap-2 align-items-end"
+                        >
+                            <div class="flex-grow-1 tie-break-set-field">
+                                <style>
+                                    #tie-break-set-wrapper { flex-direction: column; }
+                                </style>
+                                {{ admin_macros.select_input(
+                                    name='tie_break_set',
+                                    label=_('Quick-apply a tie-break set'),
+                                    placeholder=_('Choose a set…'),
+                                    select_options=tie_break_set_select_options,
+                                    tooltip_select=true,
+                                    data={}, errors={}
+                                ) }}
+                            </div>
+                            <button
+                                id="tie-break-set-apply-button"
+                                type="submit"
+                                class="btn btn-outline-primary text-nowrap
+                                    d-inline-flex align-items-center tie-break-set-action"
+                                disabled
+                            >
+                                <i class="bi-check-circle-fill pe-1"></i>
+                                {{ _('Apply') }}
+                            </button>
+                        </form>
+                        <script>
+                            (function () {
+                                var $sel = $('#tie-break-set');
+                                $sel.prop('disabled', false);
+                                $sel.removeAttr('disabled');
+                                $sel.next('.select2-container')
+                                    .find('.select2-selection')
+                                    .removeAttr('aria-disabled')
+                                    .removeClass('select2-selection--disabled');
+                                $sel.change(function () {
+                                    var v = $(this).val();
+                                    $('#tie-break-set-apply-button').prop(
+                                        'disabled', !v || v === '__placeholder__'
+                                    );
+                                });
+                                $sel.trigger('change');
+                            })();
+                        </script>
+                    </div>
+                {% endif %}
                 {% set save_as_invalid = invalid_messages_by_id|length > 0 %}
                 {% set has_custom_sets = tie_break_set_custom_names|length > 0 %}
-                {% if not rule_set_managed and (not save_as_invalid or has_custom_sets) %}
+                {% if not rule_set_managed and not only_the_points and (not save_as_invalid or has_custom_sets) %}
                     <div class="mt-3">
                         <button
                             type="button"
@@ -339,89 +397,28 @@
                                     </script>
                                 {% endif %}
                             </div>
+                            {% if not rule_set_managed and has_custom_sets %}
+                                <div class="text-end mt-3">
+                                    <button
+                                        type="button"
+                                        class="btn btn-outline-primary btn-sm text-nowrap"
+                                        hx-get="{{ url_for(
+                                            'admin-tie-break-sets-modal',
+                                            event_uniq_id=admin_event.uniq_id,
+                                            tournament_id=admin_tournament.id,
+                                        ) }}"
+                                        hx-target="body"
+                                        hx-indicator="#please-wait"
+                                        data-bs-target="#modal-wrapper"
+                                    >
+                                        <i class="bi-gear-fill pe-1"></i>
+                                        {{ _('Manage custom sets') }}
+                                    </button>
+                                </div>
+                            {% endif %}
                         </div>
                     </div>
                 {% endif %}
-            {% endif %}
-            {# Offered while nothing has been configured beyond the points, #}
-            {# which is the state a tournament starts in. #}
-            {% if only_the_points %}
-                <div class="pt-2">
-                    {% if not rule_set_managed and tie_break_set_select_options %}
-                        <form
-                            id="tie-break-set-apply-form"
-                            hx-post="{{ url_for(
-                                'admin-apply-tie-break-set',
-                                event_uniq_id=admin_event.uniq_id,
-                                tournament_id=admin_tournament.id,
-                            ) }}"
-                            hx-target="body"
-                            hx-indicator="#please-wait"
-                            class="d-flex gap-2 align-items-end"
-                        >
-                            <div class="flex-grow-1 tie-break-set-field">
-                                <style>
-                                    #tie-break-set-wrapper { flex-direction: column; }
-                                </style>
-                                {{ admin_macros.select_input(
-                                    name='tie_break_set',
-                                    label=_('Quick-apply a tie-break set'),
-                                    placeholder=_('Choose a set…'),
-                                    select_options=tie_break_set_select_options,
-                                    tooltip_select=true,
-                                    data={}, errors={}
-                                ) }}
-                            </div>
-                            <button
-                                id="tie-break-set-apply-button"
-                                type="submit"
-                                class="btn btn-outline-primary text-nowrap
-                                    d-inline-flex align-items-center tie-break-set-action"
-                                disabled
-                            >
-                                <i class="bi-check-circle-fill pe-1"></i>
-                                {{ _('Apply') }}
-                            </button>
-                        </form>
-                        <script>
-                            (function () {
-                                var $sel = $('#tie-break-set');
-                                $sel.prop('disabled', false);
-                                $sel.removeAttr('disabled');
-                                $sel.next('.select2-container')
-                                    .find('.select2-selection')
-                                    .removeAttr('aria-disabled')
-                                    .removeClass('select2-selection--disabled');
-                                $sel.change(function () {
-                                    var v = $(this).val();
-                                    $('#tie-break-set-apply-button').prop(
-                                        'disabled', !v || v === '__placeholder__'
-                                    );
-                                });
-                                $sel.trigger('change');
-                            })();
-                        </script>
-                    {% endif %}
-                </div>
-            {% endif %}
-            {% if not rule_set_managed and has_custom_sets %}
-                <div class="text-end mt-3">
-                    <button
-                        type="button"
-                        class="btn btn-outline-primary btn-sm text-nowrap"
-                        hx-get="{{ url_for(
-                            'admin-tie-break-sets-modal',
-                            event_uniq_id=admin_event.uniq_id,
-                            tournament_id=admin_tournament.id,
-                        ) }}"
-                        hx-target="body"
-                        hx-indicator="#please-wait"
-                        data-bs-target="#modal-wrapper"
-                    >
-                        <i class="bi-gear-fill pe-1"></i>
-                        {{ _('Manage custom sets') }}
-                    </button>
-                </div>
             {% endif %}
         </div>
     </div>

--- a/src/web/templates/admin/tournaments/tie_breaks_modal.html
+++ b/src/web/templates/admin/tournaments/tie_breaks_modal.html
@@ -250,7 +250,7 @@
                                 </style>
                                 {{ admin_macros.select_input(
                                     name='tie_break_set',
-                                    label=_('Quick-apply a tie-break set'),
+                                    label=_('Quick-apply a tie-break set (replace actual tie-breaks)'),
                                     placeholder=_('Choose a set…'),
                                     select_options=tie_break_set_select_options,
                                     tooltip_select=true,


### PR DESCRIPTION
Make the "Quick-apply" section always visible and move it up before the custom sets.

<img width="572" height="471" alt="image" src="https://github.com/user-attachments/assets/3d6ba1e5-3a8f-40ca-9d07-8f8b2611993a" />
