### PR TITLE
Nice vertical centering

### DIFF
--- a/src/web/static/css/base.css
+++ b/src/web/static/css/base.css
@@ -237,11 +237,6 @@ body[data-bs-theme="dark"] #top-nav-wrapper {
     margin-right: 1rem;
 }
 
-.row .input-block:has(.form-switch) {
-    height: 100%;
-    align-items: center;
-}
-
 .pw-input-group {
     flex-grow: 1;
     width: auto;
@@ -439,6 +434,11 @@ body[data-bs-theme="dark"] .htmx-indicator {
     min-width: 0;
 }
 
+.btn.compact-y-padding {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
 .collection-view-toggle .btn {
     min-width: 2.25rem;
 }
@@ -534,6 +534,7 @@ body[data-bs-theme="dark"] .htmx-indicator {
 
 .collection-details-toggle .form-check-input {
     margin-left: -2.75rem;
+    margin-top: 0;
 }
 
 .collection-card {
@@ -1144,6 +1145,11 @@ body[data-bs-theme="dark"] .htmx-indicator {
 .collection-component-drag_handle .handle:active {
     cursor: grabbing;
 }
+
+.round-control-icon {
+    top: 2px;
+}
+
 .image-screen, .card-body {
 	background-repeat: no-repeat;
 	background-position: center center;
@@ -1242,6 +1248,76 @@ body[data-bs-theme=light] {
 body[data-bs-theme=light] .nav {
     --bs-nav-link-color: #000;
     --bs-nav-link-hover-color: #000;
+}
+
+@supports (text-box-trim: trim-both) {
+    h5 {
+        text-box-trim: trim-both;
+        text-box-edge: cap alphabetic;
+    }
+
+    .btn .btn > * {
+        text-box-trim: trim-both;
+        text-box-edge: cap alphabetic;
+        padding-top: calc(var(--bs-btn-padding-y) + 0.35rem);
+        padding-bottom: calc(var(--bs-btn-padding-y) + 0.35rem);
+    }
+
+    .btn .d-inline-flex.align-items-center *{
+        text-box-trim: trim-both;
+        text-box-edge: cap alphabetic;
+    }
+
+    .btn.compact-y-padding {
+        padding-top: 0.35rem;
+        padding-bottom: 0.35rem;
+    }
+
+    .badge {
+        text-box-trim: trim-both;
+        text-box-edge: cap alphabetic;
+        --bs-badge-padding-y: 0.45rem;
+    }
+
+    .tag-badge {
+        padding-top: 0.4em;
+        padding-bottom: 0.4em;
+    }
+
+    .form-check > span {
+        display: inline-flex;
+        gap: 0.5rem;
+        align-items: center;
+    }
+
+    .form-check, .form-check span *, .form-check-label {
+        text-box-trim: trim-both;
+        text-box-edge: cap alphabetic;
+        margin-bottom: 0;
+        align-items: center;
+    }
+
+    .form-check-input {
+        margin-top: 0.05rem;
+    }
+
+    .bi, .form-check .switch-placeholder, .form-check *[data-bs-toggle="tooltip"] {
+        text-box-trim: trim-both;
+        text-box-edge: cap alphabetic;
+    }
+
+    span:has(*[data-bs-toggle="tooltip"]) {
+        line-height: 0;
+    }
+
+    .round-control-icon {
+        top:0;
+    }
+
+    th * {
+        text-box-trim: trim-both;
+        text-box-edge: cap alphabetic;
+    }
 }
 
 body[data-bs-theme=light] .btn-primary {

--- a/src/web/templates/admin/common/collection_controls.html
+++ b/src/web/templates/admin/common/collection_controls.html
@@ -7,7 +7,7 @@
         {% include collection_card_controls_template %}
     {% elif collection.card.details or collection.list.details %}
         <div
-            class="form-check form-switch collection-details-toggle mb-0"
+            class="d-inline-flex align-items-center gap-2  form-switch collection-details-toggle mb-0"
             {{ macros.tooltip_attributes('info', _('Expand or collapse the details of every item.'), 'top') }}
         >
             <input

--- a/src/web/templates/admin/common/macros.j2
+++ b/src/web/templates/admin/common/macros.j2
@@ -643,7 +643,7 @@ with_indicator: display a loading indicator, optional
                     pw-input-group
                     {% if input_type in ['password', 'search', 'integer-range', 'select-range'] %}input-group{% endif %}
                     {% if default_checkbox %}input-group{% endif %}
-                    {% if input_type == 'switch' %}form-check form-switch d-inline-block me-2{% endif %}
+                    {% if input_type == 'switch' %}form-check form-switch d-inline-flex align-items-center me-2{% endif %}
                     {% if input_type == 'checkbox' %}form-check d-inline-block me-2{% endif %}
                 "
             >
@@ -665,7 +665,7 @@ with_indicator: display a loading indicator, optional
                     ) }}
                 {% elif input_type == 'switch' or input_type == 'checkbox' %}
                     <span
-                        id="{{ id }}-input-container"
+                        id="{{ id }}-input-container input-container"
                         {% if input_tooltip %}
                             {{ macros.tooltip_attributes('', input_tooltip, 'top') }}
                         {% endif %}
@@ -683,11 +683,13 @@ with_indicator: display a loading indicator, optional
                                 disabled
                             {% endif %}
                         />
-                        {{ placeholder }}
+                        <span class="switch-placeholder">
+                            {{ placeholder }}
+                        </span>
                     </span>
                     {% if doc_icon %}<span >{{ macros.doc_icon(doc_icon, 'ms-2') }}</span>{% endif %}
                     {%- if tooltip_text and not label -%}
-                        <span class="text-nowrap">
+                        <span class="text-nowrap tooltip-icon">
                             <i
                                 class="bi bi-info-circle-fill ms-2"
                                 {{ macros.tooltip_attributes('', tooltip_text, 'top') }}
@@ -855,7 +857,7 @@ with_indicator: display a loading indicator, optional
                         <i
                             id="{{ id }}-toggle-password"
                             data-testid="{{ id }}-toggle-password"
-                            class="input-group-text {{ 'bi-eye-slash-fill' if not password_visible else 'bi-eye-fill' }} ps-2 pt-2 cursor-pointer {% if name in errors %}is-invalid{% endif %} {% if valid %}is-valid{% endif %}"
+                            class="input-group-text {{ 'bi-eye-slash-fill' if not password_visible else 'bi-eye-fill' }} cursor-pointer {% if name in errors %}is-invalid{% endif %} {% if valid %}is-valid{% endif %}"
                             hx-on:click="toggle_password(event, '#{{ id }}')"
                         ></i>
                     {% endif %}
@@ -1945,7 +1947,7 @@ with_indicator: display a loading indicator, optional
     default_state=false
 ) %}
     <div class="input-block position-relative">
-        <div class="pw-input-group form-check form-switch d-inline-block pe-3">
+        <div class="pw-input-group form-check form-switch d-inline-flex align-items-center pe-3">
             <span {% if used_message %}{{ macros.tooltip_attributes('info', used_message, 'top') }}{% endif %}>
                 <input
                     id="{{ plugin.form_key }}"
@@ -1965,7 +1967,7 @@ with_indicator: display a loading indicator, optional
                         disabled
                     {% endif %}
                 >
-                {{ plugin.name }}
+                <span>{{ plugin.name }}</span>
             </span>
             {% if used_message %}
                 <input

--- a/src/web/templates/admin/common/tag_macros.j2
+++ b/src/web/templates/admin/common/tag_macros.j2
@@ -5,7 +5,7 @@
     <span
         class="badge tag-badge rounded-pill fw-normal d-inline-flex align-items-center gap-1 {{ class }}"
         style="background-color: {{ tag.color }}; color: {{ tag.text_color }};"
-    >{{ tag.name }}{% if count is not none %}<span class="opacity-75">({{ count }})</span>{% endif %}</span>
+    ><span>{{ tag.name }}</span>{% if count is not none %}<span class="opacity-75">({{ count }})</span>{% endif %}</span>
 {% endmacro %}
 
 {% macro tag_badges(tags, class='') %}

--- a/src/web/templates/admin/index/events_tag_filter.html
+++ b/src/web/templates/admin/index/events_tag_filter.html
@@ -47,7 +47,7 @@
                             ) !important;
                         "
                     >
-                        {{ tag.name }}
+                        <span>{{ tag.name }}</span>
                         <span class="opacity-75">({{ count }})</span>
                     </span>
                 {% endif %}

--- a/src/web/templates/admin/pairings/round_controls.html
+++ b/src/web/templates/admin/pairings/round_controls.html
@@ -14,7 +14,7 @@
                     hx-trigger="click, SC_Ctrl_Shift_ArrowLeft from:body"
                 {% endif %}
             >
-                <i class="bi bi-skip-backward-fill position-relative" style="top: 2px;"></i>
+                <i class="bi bi-skip-backward-fill position-relative round-control-icon"></i>
             </button>
         </span>
         <span {{ macros.tooltip_attributes('info', _('Previous round'), 'bottom') }}>
@@ -32,7 +32,7 @@
                     hx-trigger="click, SC_Shift_ArrowLeft from:body"
                 {% endif %}
             >
-                <i class="bi bi-play-fill position-relative" style="top: 2px;"></i>
+                <i class="bi bi-play-fill position-relative round-control-icon"></i>
             </button>
         </span>
         <select
@@ -86,7 +86,7 @@
                     hx-trigger="click, SC_Shift_ArrowRight from:body"
                 {% endif %}
             >
-                <i class="bi-play-fill position-relative" style="top: 2px;"></i>
+                <i class="bi-play-fill position-relative round-control-icon"></i>
             </button>
         </span>
         <span {{ macros.tooltip_attributes('info', _('Current round'), 'bottom') }}>
@@ -107,7 +107,7 @@
                     hx-trigger="click, SC_Ctrl_Shift_ArrowRight from:body"
                 {% endif %}
             >
-                <i class="bi bi-fast-forward-fill position-relative" style="top: 2px;"></i>
+                <i class="bi bi-fast-forward-fill position-relative round-control-icon"></i>
             </button>
         </span>
     </div>

--- a/src/web/templates/admin/players/record_modal.html
+++ b/src/web/templates/admin/players/record_modal.html
@@ -250,7 +250,7 @@
                                     >
                                         <button
                                             type="button"
-                                            class="btn btn-sm btn-outline-primary ms-1 px-1 py-0"
+                                            class="btn btn-sm compact-y-padding btn-outline-primary ms-1 px-1"
                                             {% if _round_paired %}
                                                 hx-get="{{ url_for(
                                                     'admin-player-point-adjustment-modal',

--- a/src/web/templates/admin/players/table/cells/tournament.html
+++ b/src/web/templates/admin/players/table/cells/tournament.html
@@ -3,7 +3,7 @@
 {% else %}
     <span class="dropdown">
         <button
-            class="btn btn-secondary dropdown-toggle mx-0 px-2 py-0 w-100 d-inline-flex align-items-center justify-content-between"
+            class="btn btn-secondary dropdown-toggle mx-0 compact-padding px-2 w-100 d-inline-flex align-items-center justify-content-between"
             type="button"
             data-bs-toggle="dropdown"
             aria-expanded="false"

--- a/src/web/templates/admin/players/table/filter.html
+++ b/src/web/templates/admin/players/table/filter.html
@@ -1,7 +1,7 @@
 {% set is_active = column.has_active_filter_value %}
 <form
     id="column-{{ column.id }}-filter"
-    class="d-inline-block ps-1"
+    class="d-inline-flex align-items-center ps-1"
     hx-get="{{ url_for(
         'admin-event-players-set-filter',
         event_uniq_id=admin_event.uniq_id,
@@ -35,7 +35,7 @@
                     {% if column.all_filter_value_active %}checked{% endif %}
                     onclick="$('input.filter-{{ column.id }}').prop('checked', this.checked)"
                 />
-                <button type="submit" class="btn w-100 text-end py-0" data-bs-dismiss="modal" >
+                <button type="submit" class="btn w-100 text-end compact-y-padding" data-bs-dismiss="modal" >
                     <i class="bi-check-lg pe-1"></i>
                     {{ _('OK') }}
                 </button>

--- a/src/web/templates/admin/players/table/header.html
+++ b/src/web/templates/admin/players/table/header.html
@@ -14,7 +14,7 @@
             {# Covers the buttons, index and title columns #}
             <div class="d-flex align-items-center">
                 <i
-                    class="bi-arrow-clockwise btn text-dark py-0 ps-0 pe-1 m-0"
+                    class="bi-arrow-clockwise btn text-dark compact-y-padding ps-0 pe-1 m-0"
                     hx-get="{{ url }}"
                     hx-target="body"
                     hx-indicator="#please-wait"
@@ -24,7 +24,7 @@
                     {{ filtered_player_count }}/{{ allowed_players|length }}
                 </span>
                 <i
-                    class="bi-x-circle btn text-dark py-0 ps-1 pe-0 m-0"
+                    class="bi-x-circle btn text-dark compact-y-padding ps-1 pe-0 m-0"
                     hx-get="{{ url_for('admin-event-players-clear-filters', event_uniq_id=admin_event.uniq_id) }}"
                     hx-target="body"
                     hx-indicator="#please-wait"
@@ -37,7 +37,7 @@
             <th id="column-{{ column.id }}-header" class="{{ column.header_classes }} {% if column.is_compact %}compact-col{% endif %}">
                 <div class="d-flex {% if not column.align_start %}justify-content-center{% endif %}">
                     <div
-                        class="cursor-pointer d-flex"
+                        class="cursor-pointer d-flex align-items-center"
                         hx-get="{{ url_for(
                             'admin-event-players-sort',
                             event_uniq_id=admin_event.uniq_id,
@@ -50,7 +50,9 @@
                         {% if column.header_template %}
                             {% include column.header_template %}
                         {% else %}
-                            {{ column.header_content }}
+                            <span>
+                                {{ column.header_content }}
+                            </span>
                         {% endif %}
                         {% if is_sort_column %}
                             {% set is_asc_sort_icon = not is_sort_asc if column.swap_asc_desc_icon else is_sort_asc %}

--- a/src/web/templates/admin/players/table/row.html
+++ b/src/web/templates/admin/players/table/row.html
@@ -21,7 +21,7 @@
         ) %}
         {% if can_update or can_update_history or can_delete %}
             <span class="dropdown">
-                <button class="btn btn-secondary dropdown-toggle mx-0 px-1 py-0" type="button" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" >
+                <button class="btn btn-secondary compact-y-padding dropdown-toggle mx-0 px-1" type="button" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false" >
                     <i class="bi-three-dots"></i>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-start table-dropdown-menu p-0" >

--- a/src/web/templates/admin/players/team_record_modal.html
+++ b/src/web/templates/admin/players/team_record_modal.html
@@ -125,7 +125,7 @@
                                     >
                                         <button
                                             type="button"
-                                            class="btn btn-sm btn-outline-primary ms-1 px-1 py-0"
+                                            class="btn btn-sm compact-y-padding btn-outline-primary ms-1 px-1"
                                             {% if _round_paired %}
                                                 hx-get="{{ url_for(
                                                     'admin-team-point-adjustment-modal',

--- a/src/web/templates/admin/prizes/prize_category_form_modal.html
+++ b/src/web/templates/admin/prizes/prize_category_form_modal.html
@@ -59,7 +59,7 @@
                         ) }}
                     </div>
                     <div class="col-12">
-                        <div class="d-flex">
+                        <div class="d-flex align-items-center">
                             <span
                                 class="fit-content"
                                 {% if other_main_category or has_criteria %}
@@ -84,17 +84,19 @@
                                     data=data, errors=errors
                                 ) }}
                             </span>
-                            <i
-                                class="bi bi-info-circle-fill"
-                                {{ macros.tooltip_attributes(
-                                    'info', _('The main category is open to all the players.'), 'top'
-                                ) }}
-                            ></i>
+                            <span>
+                                <i
+                                    class="bi bi-info-circle-fill"
+                                    {{ macros.tooltip_attributes(
+                                        'info', _('The main category is open to all the players.'), 'top'
+                                    ) }}
+                                ></i>
+                            </span>
                         </div>
                     </div>
                     {% set has_non_monetary_prizes = admin_prize_category and admin_prize_category.has_non_monetary_prizes %}
                     <div class="col-12">
-                        <div class="d-flex">
+                        <div class="d-flex align-items-center">
                             <span
                                 id="share-prizes-container"
                                 {{ macros.tooltip_attributes(

--- a/src/web/templates/admin/teams/team_lineups_modal.html
+++ b/src/web/templates/admin/teams/team_lineups_modal.html
@@ -109,7 +109,7 @@
                             {% if editable %}
                                 <button
                                     type="button"
-                                    class="lineup-reset-order btn btn-sm py-0 text-nowrap"
+                                    class="lineup-reset-order btn btn-sm compact-padding text-nowrap"
                                 >
                                     {{ _('Reset order') }}
                                 </button>

--- a/src/web/templates/common/macros.j2
+++ b/src/web/templates/common/macros.j2
@@ -126,7 +126,7 @@
 
 {% macro doc_icon(url, class) %}
     <a href="{{ doc_url(url) }}" target="_blank" class="{{ class }}">
-        <i class="bi-info-circle"></i>
+        <i class="bi bi-info-circle"></i>
     </a>
 {% endmacro %}
 


### PR DESCRIPTION
There's a new CSS selector that allows for the bounding box of text to be such that ascenders and descenders are ignored, making it at long last possible to center text vertically.

It's now been implemented in Firefox, so it's finally available in all major browsers.

This PR applies it conditionally when it's available along with a few style changes that are required.  To test that this doesn't break the UI for older browsers you can rename `trim-both` to something else that won't be recognised such as `trim-both-x` in the following line:

```css
@supports (text-box-trim: trim-both) {
```

The difference is subtle, but these misalignments have always been source of annoyance to my eyes :)
Before above, after below: 

<img width="412" height="418" alt="valign" src="https://github.com/user-attachments/assets/24e5cd4f-7e44-48cf-88e4-c5f36d447100" />

